### PR TITLE
(ASC-221) Run test_cinder_service on dashboard_hosts

### DIFF
--- a/molecule/default/tests/test_dashboard.py
+++ b/molecule/default/tests/test_dashboard.py
@@ -1,0 +1,20 @@
+import os
+import re
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('dashboard_hosts')
+
+
+@pytest.mark.jira('asc-222')
+def test_cinder_service(host):
+    """Test to verify that cinder service is running on the cinder nodes
+
+    Args:
+        host(testinfra.host.Host): A hostname in dynamic_inventory.json/molecule.yml
+    """
+
+    cmd = "sudo bash -c \"source /root/openrc; cinder service-list\""
+    output = host.run(cmd)
+    assert ("cinder-volume" in output.stdout)

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -8,22 +8,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 
 @pytest.mark.jira('asc-222')
-@pytest.mark.skip(reason='this test can not run on storage host')
-# TODO: will update the test to run cinder command on controller node
-# TODO: since the test cannot run on storage hosts.
-def test_cinder_service(host):
-    """Test to verify that cinder service is running on the cinder nodes
-
-    Args:
-        host(testinfra.host.Host): A hostname in dynamic_inventory.json/molecule.yml
-    """
-
-    cmd = "sudo bash -c \"source /root/openrc; cinder service-list\""
-    output = host.run(cmd)
-    assert ("cinder-volume" in output.stdout)
-
-
-@pytest.mark.jira('asc-222')
 def test_cinder_lvm_volume(host):
     """Test 2a: Check the Cinder Nodes: volume group
 


### PR DESCRIPTION
This commit moves the `test_cinder_service` into a `test_dashboard`
file that gathers hosts in the `dashboard_hosts` group to execute the
test on.  This test relies on the `cinder` command-line interface
which is not installed on the `cinder_volume` hosts.