### PR TITLE
RO-4091 fix ci failure

### DIFF
--- a/molecule/default/tests/test_dashboard.py
+++ b/molecule/default/tests/test_dashboard.py
@@ -4,7 +4,7 @@ import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('dashboard_hosts')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('infra1')
 
 
 @pytest.mark.jira('asc-222')

--- a/molecule/default/tests/test_dashboard.py
+++ b/molecule/default/tests/test_dashboard.py
@@ -4,7 +4,7 @@ import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('infra1')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('dashboard_hosts')[:1]
 
 
 @pytest.mark.jira('asc-222')


### PR DESCRIPTION
Prior to this PR, dashboard_hosts host group has 3 controller hosts: infra1, infra2, and infra3. Only infra1 has authentication file /root/openrc so the test failed on infra2 and infra3. We need to copy the file from infra1 to infra2 and infra3 the test need to run on all controllers. However for this test, we only need to run it from one controller.

This PR to replace all 3 controller nodes by only `infra1`