### PR TITLE
(ASC-618) fix cinder failure on newton

### DIFF
--- a/molecule/default/tests/test_cinder_volume.py
+++ b/molecule/default/tests/test_cinder_volume.py
@@ -24,7 +24,7 @@ def test_cinder_volume_created(host):
 
     # Create a test volume
     test_volume_name = "test_volume_compute1"
-    cmd1 = "{} openstack volume create --size 1 {}'".format(utility_container, test_volume_name)
+    cmd1 = "{} openstack volume create --size 1 --availability-zone nova {}'".format(utility_container, test_volume_name)
     host.run_expect([0], cmd1)
 
     # Verify the volume is created

--- a/molecule/default/tests/utils.py
+++ b/molecule/default/tests/utils.py
@@ -26,7 +26,7 @@ def create_bootable_volume(data, run_on_host):
     imageRef = data['volume']['imageRef']
     volume_name = data['volume']['name']
 
-    cmd = "{} openstack volume create --size {} --image {} --multi-attach --bootable {}'".format(utility_container, volume_size, imageRef, volume_name)
+    cmd = "{} openstack volume create --size {} --image {} --availability-zone nova --bootable {}'".format(utility_container, volume_size, imageRef, volume_name)
 
     output = run_on_host.run(cmd)
     print ("\n----------- Create_bootable volume output: ----------\n")


### PR DESCRIPTION
Prior to this PR the test that creates volume using command like `openstack volume create --size 1 volume_name`, without using argument `--availability-zone` as it is not a mandatory argument in latest openstack doc.

Create volume test passed in Master(Queens) and Pike, but failed in newly added Newton CI. Looking at the doc for Newton, the argument `--availability-zone` is in the example of create a volume (https://docs.openstack.org/newton/user-guide/common/cli-manage-volumes.html)

This PR to add the above argument to the test.