### PR TITLE
ASC-636 Fix bootable zone key

### DIFF
--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -27,7 +27,7 @@ def test_create_bootable_volume(host):
     data = {
         "volume": {
             "size": 1,
-            "availability_zone": zone,
+            "zone": zone,
             "source_volid": null,
             "description": null,
             "multiattach": false,


### PR DESCRIPTION
This commit updates the data key supplied to the
`create_bootable_volume` helper in the `test_create_bootable_volume.py`
test. The data key used in the helper was changed from
`availability_zone` to `zone`. This change simply updates the calling
code to pass in a key of the same name.