### PR TITLE
(ASC-462) added test case create instance from bootable volume

### DIFF
--- a/molecule/default/tests/test_cinder_volume.py
+++ b/molecule/default/tests/test_cinder_volume.py
@@ -23,9 +23,13 @@ def test_cinder_volume_created(host):
     """Verify cinder volume can be created"""
 
     # Create a test volume
-    test_volume_name = "test_volume_compute1"
-    cmd = "{} openstack volume create --size 1 --availability-zone nova {}'".format(utility_container, test_volume_name)
+    random_str = utils.generate_random_string(4)
+    volume_name = "test_volume_{}".format(random_str)
+    cmd = "{} openstack volume create --size 1 --availability-zone nova {}'".format(utility_container, volume_name)
     host.run_expect([0], cmd)
 
     # Verify the volume is created
-    utils.verify_volume(test_volume_name, host)
+    assert volume_name in utils.openstack_name_list('volume', host)
+
+    # Tear down
+    utils.delete_volume(volume_name, host)

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -22,7 +22,7 @@ def test_create_bootable_volume(host):
     image_name = 'Cirros-0.3.5'
     zone = 'nova'
 
-    image_id = utils.get_image_id(image_name, host)
+    image_id = utils.get_id_by_name('image', image_name, host)
 
     data = {
         "volume": {
@@ -43,7 +43,7 @@ def test_create_bootable_volume(host):
 
     utils.create_bootable_volume(data, host)
 
-    utils.verify_volume(volume_name, host)
+    assert volume_name in utils.openstack_name_list('volume', host)
 
     # Tear down
     utils.delete_volume(volume_name, host)

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -48,9 +48,7 @@ def test_create_instance_from_bootable_volume(host):
     """
 
     volume_id = utils.get_id_by_name('volume', volume_name, host)
-    # Fail test if the image_id is None
-    if volume_id is None:
-        pytest.xfail("Image Id can not be None")
+    assert volume_id is not None
 
     network_id = utils.get_id_by_name('network', network_name, host)
     assert network_id is not None

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -1,0 +1,68 @@
+import utils
+import os
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('os-infra_hosts')[:1]
+
+utility_container = ("lxc-attach -n $(lxc-ls -1 | grep utility | head -n 1) "
+                     "-- bash -c '. /root/openrc ; ")
+
+random_str = utils.generate_random_string(6)
+volume_name = "test_volume_{}".format(random_str)
+instance_name = "test_instance_{}".format(random_str)
+image_name = 'Cirros-0.3.5'
+network_name = 'PRIVATE_NET'
+flavor = 'm1.tiny'
+
+
+@pytest.mark.test_id('73c5d0b2-7584-11e8-ba5b-fe14fb7452aa')
+@pytest.mark.jira('asc-462')
+@pytest.mark.run(order=1)
+def test_create_bootable_volume(host):
+    """Test to verify that a bootable volume can be created based on a Glance image
+
+    Args:
+        host(testinfra.host.Host): A hostname in dynamic_inventory.json/molecule.yml
+    """
+
+    image_id = utils.get_id_by_name('image', image_name, host)
+    assert image_id is not None
+
+    cmd = "{} openstack volume create --size 1 --image {} --bootable {}'".format(utility_container, image_id, volume_name)
+    host.run_expect([0], cmd)
+
+    assert volume_name in utils.openstack_name_list('volume', host)
+    assert (utils.get_expected_value('volume', volume_name, 'status', 'available', host))
+
+
+@pytest.mark.test_id('8b701dbc-7584-11e8-ba5b-fe14fb7452aa')
+@pytest.mark.jira('asc-462')
+@pytest.mark.run(order=2)
+def test_create_instance_from_bootable_volume(host):
+    """Test to verify that a bootable volume can be created based on a Glance image
+
+    Args:
+        host(testinfra.host.Host): A hostname in dynamic_inventory.json/molecule.yml
+    """
+
+    volume_id = utils.get_id_by_name('volume', volume_name, host)
+    # Fail test if the image_id is None
+    if volume_id is None:
+        pytest.xfail("Image Id can not be None")
+
+    network_id = utils.get_id_by_name('network', network_name, host)
+    assert network_id is not None
+
+    cmd = "{} openstack server create --volume {} --flavor {} --nic net-id={} {}'".format(utility_container, volume_id, flavor, network_id, instance_name)
+
+    host.run_expect([0], cmd)
+
+    assert instance_name in utils.openstack_name_list('server', host)
+    assert (utils.get_expected_value('server', instance_name, 'status', 'ACTIVE', host))
+    assert (utils.get_expected_value('server', instance_name, 'OS-EXT-STS:power_state', 'Running', host))
+
+    # Tear down
+    utils.delete_instance(instance_name, host)
+    utils.delete_volume(volume_name, host)


### PR DESCRIPTION
This PR does:
1. Added new test case of `create instance from a bootable volume`. Note that this test will fail in Newton because of missing '--bootable' flag in newton openstack cli. Will create a different ticket for fixing Newton CI failure.
2. Added method generate_random_string to get volume/server name dynamically in order to avoid the fact that a test executed twice will create same volume/server names with different IDs, this might cause an issue for tests executed after that test.
