### PR TITLE
ASC-813 Update tests for pytest-rpc 0.11.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 molecule~=2.14
 ansible==2.4.3
+pytest_rpc>=0.11.0

--- a/molecule/default/tests/test_cinder_volume.py
+++ b/molecule/default/tests/test_cinder_volume.py
@@ -29,7 +29,10 @@ def test_cinder_volume_created(host):
     host.run_expect([0], cmd)
 
     # Verify the volume is created
-    assert volume_name in helpers.openstack_name_list('volume', host)
+    volumes = helpers.get_resource_list_by_name('volume', host)
+    assert volumes
+    volume_names = [x['Name'] for x in volumes]
+    assert volume_name in volume_names
 
     # Tear down
     helpers.delete_volume(volume_name, host)

--- a/molecule/default/tests/test_create_bootable_volume.py
+++ b/molecule/default/tests/test_create_bootable_volume.py
@@ -34,7 +34,7 @@ def test_create_bootable_volume(host):
             "snapshot_id": null,
             "backup_id": null,
             "name": volume_name,
-            "imageRef": image_id,
+            "imageref": image_id,
             "volume_type": null,
             "metadata": {},
             "consistencygroup_id": null
@@ -43,7 +43,10 @@ def test_create_bootable_volume(host):
 
     helpers.create_bootable_volume(data, host)
 
-    assert volume_name in helpers.openstack_name_list('volume', host)
+    volumes = helpers.get_resource_list_by_name('volume', host)
+    assert volumes
+    volume_names = [x['Name'] for x in volumes]
+    assert volume_name in volume_names
 
     # Tear down
     helpers.delete_volume(volume_name, host)

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -33,7 +33,10 @@ def test_create_bootable_volume(host):
     cmd = "{} openstack volume create --size 1 --image {} --bootable {}'".format(utility_container, image_id, volume_name)
     host.run_expect([0], cmd)
 
-    assert volume_name in helpers.openstack_name_list('volume', host)
+    volumes = helpers.openstack_name_list('volume', host)
+    assert volumes
+    volume_names = [x['Name'] for x in volumes]
+    assert volume_name in volume_names
     assert (helpers.get_expected_value('volume', volume_name, 'status', 'available', host))
 
 
@@ -57,7 +60,10 @@ def test_create_instance_from_bootable_volume(host):
 
     host.run_expect([0], cmd)
 
-    assert instance_name in helpers.openstack_name_list('server', host)
+    instances = helpers.openstack_name_list('server', host)
+    assert instances
+    instance_names = [x['Name'] for x in instances]
+    assert instance_name in instance_names
     assert (helpers.get_expected_value('server', instance_name, 'status', 'ACTIVE', host))
     assert (helpers.get_expected_value('server', instance_name, 'OS-EXT-STS:power_state', 'Running', host))
 


### PR DESCRIPTION
This PR updates tests using helpers from pytest-rpc to be compatible
with the breaking api changes for these helpers in version 0.11.0.