### PR TITLE
(ASC-855) remove dup run of openstack service setup on cinder

### DIFF
--- a/tasks/cloning_openstack_ansible_ops.yml
+++ b/tasks/cloning_openstack_ansible_ops.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for molecule-validate-cinder-deploy
+
+- name: Clean old openstack-ansible-ops dir if previously existing
+  file:
+    state: absent
+    path: /opt/openstack-ansible-ops
+
+- name: Clone openstack-ansible-ops repo
+  git:
+    repo=https://github.com/openstack/openstack-ansible-ops.git
+    dest=/opt/openstack-ansible-ops

--- a/tasks/create_virtualenv_on_sut.yml
+++ b/tasks/create_virtualenv_on_sut.yml
@@ -1,0 +1,17 @@
+---
+# tasks file for molecule-validate-cinder-deploy
+
+- name: Create virtualenv for the submodule
+  shell: virtualenv /opt/molecule-test-env-on-sut
+
+- name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
+  pip:
+    name: "{{ item }}"
+    extra_args: --isolated
+    state: present
+    virtualenv: /opt/molecule-test-env-on-sut
+  with_items:
+    - ansible==2.5.5
+    - shade==1.28.0
+    - ipaddr==2.2.0
+    - netaddr==0.7.19

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,45 +1,11 @@
 ---
 # tasks file for molecule-validate-cinder-deploy
 
-- name: Clean old openstack-ansible-ops dir if previously existing
-  file:
-    state: absent
-    path: /opt/openstack-ansible-ops
+- import_tasks: cloning_openstack_ansible_ops.yml
+  when: ansible_local.service_setup is not defined
 
-- name: Clone openstack-ansible-ops repo
-  git:
-    repo=https://github.com/openstack/openstack-ansible-ops.git
-    dest=/opt/openstack-ansible-ops
+- import_tasks: create_virtualenv_on_sut.yml
+  when: ansible_local.service_setup is not defined
 
-- name: Create virtualenv for the submodule
-  shell: virtualenv /opt/molecule-test-env-on-sut
-
-- name: Install python modules into /opt/molecule-test-env-on-sut virtualenv
-  pip:
-    name: "{{ item }}"
-    extra_args: --isolated
-    state: present
-    virtualenv: /opt/molecule-test-env-on-sut
-  with_items:
-    - ansible==2.5.5
-    - shade==1.28.0
-    - ipaddr==2.2.0
-    - netaddr==0.7.19
-
-- name: Find the proper inventory file
-  shell: find /opt/openstack-ansible -name dynamic_inventory.py -print
-  register: find_inventory_file
-  ignore_errors: True
-
-- name: Set proper inventory file
-  set_fact:
-    inventory_file: "{{ find_inventory_file.stdout }}"
-
-- name: Create networks
-  shell: |
-    . /opt/molecule-test-env-on-sut/bin/activate
-    ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i {{ inventory_file }} openstack-service-setup.yml
-    deactivate
-  args:
-    executable: /bin/bash
-    chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
+- import_tasks: run_openstack_service_setup_playbook.yml
+  when: ansible_local.service_setup is not defined

--- a/tasks/run_openstack_service_setup_playbook.yml
+++ b/tasks/run_openstack_service_setup_playbook.yml
@@ -1,0 +1,34 @@
+---
+# tasks file for molecule-validate-cinder-deploy
+
+- name: Find the proper inventory file
+  shell: find /opt/openstack-ansible -name dynamic_inventory.py -print
+  register: find_inventory_file
+  ignore_errors: True
+
+- name: Set proper inventory file
+  set_fact:
+    inventory_file: "{{ find_inventory_file.stdout }}"
+
+- name: Run openstack-service-setup.yml playbook in virtualenv on SUT
+  shell: |
+    . /opt/molecule-test-env-on-sut/bin/activate
+    ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i {{ inventory_file }} openstack-service-setup.yml
+    deactivate
+  args:
+    executable: /bin/bash
+    chdir: /opt/openstack-ansible-ops/multi-node-aio-xenial-ansible/playbooks/
+
+- name: create directory for ansible custome facts
+  file:
+    state: directory
+    recurse: yes
+    path: /etc/ansible/facts.d
+
+- name: install custom fact for service setup
+  copy:
+    content: "{\"already_ran\" : \"true\"}"
+    dest: /etc/ansible/facts.d/service_setup.fact
+
+- name: re-read facts after adding custome fact
+  setup: filter=ansible_local


### PR DESCRIPTION
System tests run openstack-service-setup.yml in each and every single molecule submodule, this duplication effort is unnecessary, slowing down test, and causing errors when idempotent is failing.

This PR adds condition check, if openstack-service-setup.yml has been run successfully once, it should not run again on Cinder.