### PR TITLE
ASC-813 Add fail-over for newton volume key

### DIFF
--- a/molecule/default/tests/test_cinder_volume.py
+++ b/molecule/default/tests/test_cinder_volume.py
@@ -31,7 +31,12 @@ def test_cinder_volume_created(host):
     # Verify the volume is created
     volumes = helpers.get_resource_list_by_name('volume', host)
     assert volumes
-    volume_names = [x['Name'] for x in volumes]
+
+    try:
+        volume_names = [x['Name'] for x in volumes]
+    except KeyError:
+        volume_names = [x['Display Name'] for x in volumes]  # for newton
+
     assert volume_name in volume_names
 
     # Tear down


### PR DESCRIPTION
This commit adds fail-over lookup for volume data returned by the
openstack cli. In newton, the key for the volume name is 'Display Name'
rather than just 'Name'.