### PR TITLE
ASC-813 Remove volume tear-down step

### DIFF
--- a/molecule/default/tests/test_cinder_volume.py
+++ b/molecule/default/tests/test_cinder_volume.py
@@ -38,6 +38,3 @@ def test_cinder_volume_created(host):
         volume_names = [x['Display Name'] for x in volumes]  # for newton
 
     assert volume_name in volume_names
-
-    # Tear down
-    helpers.delete_volume(volume_name, host)


### PR DESCRIPTION
This commit removes the volume tear-down step because the `delete_it`
helper is not currently compatible with newton.