### PR TITLE
MAINT - Patch cinder tests

### DIFF
--- a/molecule/default/tests/test_cinder_lvm.py
+++ b/molecule/default/tests/test_cinder_lvm.py
@@ -23,10 +23,13 @@ ssh_pre = ("ssh -o UserKnownHostsFile=/dev/null "
 @pytest.mark.test_id('b1e888fa-546a-11e8-9902-6c96cfdb252f')
 def test_cinder_lvs_volume_on_node(host):
     # get list of volumes and associated hosts from utility container
-    cmd = "{} cinder list --all-t --fields os-vol-host-attr:host '".format(os_pre)
+    cmd = "{} cinder list --all-t --fields os-vol-host-attr:host,status '".format(os_pre)
     vol_table = host.run(cmd).stdout
     vol_hosts = helpers.parse_table(vol_table)[1]
-    for vol, chost in vol_hosts:
+    for vol, chost, status in vol_hosts:
+        print vol, chost, status
+        if status != 'available':
+            continue
         chost = chost.split('@')[0].split('.')[0]
         # VOLEXISTS test
         cmd = "{} {} lvs | grep volume-{}".format(ssh_pre, chost, vol)

--- a/molecule/default/tests/test_create_instance_from_bootable_volume.py
+++ b/molecule/default/tests/test_create_instance_from_bootable_volume.py
@@ -37,7 +37,8 @@ def test_create_bootable_volume(host):
     assert volumes
     volume_names = [x['Name'] for x in volumes]
     assert volume_name in volume_names
-    assert (helpers.get_expected_value('volume', volume_name, 'status', 'available', host))
+    assert helpers.get_expected_value('volume', volume_name, 'status',
+                                      'available', host, retries=50)
 
 
 @pytest.mark.test_id('8b701dbc-7584-11e8-ba5b-fe14fb7452aa')
@@ -49,6 +50,12 @@ def test_create_instance_from_bootable_volume(host):
     Args:
         host(testinfra.host.Host): A hostname in dynamic_inventory.json/molecule.yml
     """
+
+    # Fail fast if the previous test didn't pass
+    vol_avail = helpers.get_expected_value('volume', volume_name, 'status',
+                                           'available', host, retries=1)
+    if not vol_avail:
+            pytest.skip("Dependent volume not avail")
 
     volume_id = helpers.get_id_by_name('volume', volume_name, host)
     assert volume_id is not None


### PR DESCRIPTION
Increase timeout for cinder bootable volume creation.

Decouple dependent tests from bootable volume creation.